### PR TITLE
fix: corrigindon erro ssl na conexão do Keycloak

### DIFF
--- a/src/main/java/br/com/inkinvite/infrastructure/security/KeycloakProvider.java
+++ b/src/main/java/br/com/inkinvite/infrastructure/security/KeycloakProvider.java
@@ -1,6 +1,14 @@
 package br.com.inkinvite.infrastructure.security;
 
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
@@ -10,6 +18,7 @@ import jakarta.inject.Singleton;
 
 @Singleton
 public class KeycloakProvider {
+
     @Inject
     @ConfigProperty(name = "URL_ONLY")
     private String serverURL;
@@ -34,38 +43,60 @@ public class KeycloakProvider {
     @ConfigProperty(name = "KC_PASSWORD")
     private String adminSenha;
 
+    private SSLContext createSSLContext() throws Exception {
+        TrustManager[] trustAllCerts = new TrustManager[] {
+            new X509TrustManager() {
+                public X509Certificate[] getAcceptedIssuers() {
+                    return null;
+                }
+                public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                }
+                public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                }
+            }
+        };
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, trustAllCerts, new SecureRandom());
+        return sslContext;
+    }
+
+    private Keycloak buildKeycloakClient(String username, String password, String grantType) {
+        try {
+            SSLContext sslContext = createSSLContext();
+
+            KeycloakBuilder builder = KeycloakBuilder.builder()
+                .resteasyClient(ResteasyClientBuilder.newBuilder()
+                    .sslContext(sslContext)
+                    .hostnameVerifier((hostname, session) -> true)
+                    .build())
+                .serverUrl(serverURL)
+                .realm(realmName)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .grantType(grantType);
+
+            if (username != null && password != null) {
+                builder.username(username).password(password);
+            }
+
+            return builder.build();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
     public Keycloak obterClientKeycloak() {
-        return KeycloakBuilder.builder()
-            .serverUrl(serverURL)
-            .realm(realmName)
-            .clientId(clientId)
-            .clientSecret(clientSecret)
-            .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
-            .build();
+        return buildKeycloakClient(null, null, OAuth2Constants.CLIENT_CREDENTIALS);
     }
 
     public Keycloak obterClientKeycloakPorLogin(String login, String senha) {
-        return KeycloakBuilder.builder()
-                .serverUrl(serverURL)
-                .realm(realmName)
-                .clientId(clientId)
-                .clientSecret(clientSecret)
-                .username(login)
-                .password(senha)
-                .grantType(OAuth2Constants.PASSWORD)
-                .build();
+        return buildKeycloakClient(login, senha, OAuth2Constants.PASSWORD);
     }
 
     public Keycloak obterValidacaoAdmin() {
-        return KeycloakBuilder.builder()
-                .serverUrl(serverURL)
-                .realm(realmName)
-                .clientId(clientId)
-                .clientSecret(clientSecret)
-                .username(adminLogin)
-                .password(adminSenha)
-                .grantType(OAuth2Constants.PASSWORD)
-                .build();
+        return buildKeycloakClient(adminLogin, adminSenha, OAuth2Constants.PASSWORD);
     }
 
     public String getRealmName() {


### PR DESCRIPTION
O que foi feito?
* Corrigindo o problema de conexão insegura via criação de contexto sem verificação SSL.

Como foi feito?
* Através do método `createSSLContext` que é chamado em toda a requisição externa junto ao servidor Keycloak.